### PR TITLE
Add support for Environment Variables 

### DIFF
--- a/internal/app/tfsec/parser/load_env_vars.go
+++ b/internal/app/tfsec/parser/load_env_vars.go
@@ -1,0 +1,44 @@
+package parser
+
+import (
+	"fmt"
+	"github.com/zclconf/go-cty/cty"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const TF_ENV_VAR = "TF_VAR_"
+
+func LoadEnvVars(inputVars map[string]cty.Value) (map[string]cty.Value, error){
+	file, err := ioutil.TempFile("./","tmp")
+	if err != nil {
+		return inputVars, err
+	}
+	defer func() {
+		file.Close()
+		os.Remove(file.Name())
+	}()
+
+	for _, env := range os.Environ() {
+		pair := strings.Split(env, "=")
+		key, val := pair[0], pair[1]
+		if strings.Contains(key, TF_ENV_VAR) {
+			key := strings.TrimPrefix(key,TF_ENV_VAR)
+			// Since env variables take lower precedence, only update if tfvars has not included a value yet
+			if _, ok := inputVars[key]; !ok {
+				file.WriteString(fmt.Sprintf("%s=%s\n", key, val))
+			}
+		}
+	}
+	envVars, err := LoadTFVars(file.Name())
+	if err != nil {
+		return inputVars, nil
+	}
+
+	for key, val := range envVars {
+		inputVars[key] = val
+	}
+
+	return inputVars, nil
+}

--- a/internal/app/tfsec/parser/parser.go
+++ b/internal/app/tfsec/parser/parser.go
@@ -77,9 +77,7 @@ func (parser *Parser) ParseDirectory() (Blocks, error) {
 		return nil, err
 	}
 	t.Stop()
-	for key, val := range inputVars {
-		debug.Log("%s%s", key, val)
-	}
+
 	debug.Log("Loading module metadata...")
 	t = timer.Start(timer.DiskIO)
 	modulesMetadata, _ := LoadModuleMetadata(parser.fullPath)

--- a/internal/app/tfsec/parser/parser.go
+++ b/internal/app/tfsec/parser/parser.go
@@ -70,6 +70,16 @@ func (parser *Parser) ParseDirectory() (Blocks, error) {
 	}
 	t.Stop()
 
+	debug.Log("Loading environment variables...")
+	t = timer.Start(timer.DiskIO)
+	inputVars, err = LoadEnvVars(inputVars)
+	if err != nil {
+		return nil, err
+	}
+	t.Stop()
+	for key, val := range inputVars {
+		debug.Log("%s%s", key, val)
+	}
 	debug.Log("Loading module metadata...")
 	t = timer.Start(timer.DiskIO)
 	modulesMetadata, _ := LoadModuleMetadata(parser.fullPath)


### PR DESCRIPTION
### Context 
Currently, tfsec supports the ability to read variables from .tfvars, but it does not read environment variables that have been set via:
`export TF_VAR_variable=value` 
However, this is a supported feature in Terraform: https://www.terraform.io/docs/cli/config/environment-variables.html#tf_var_name

### Intent 
We want to add the ability to extrapolate global environment variables - particularly if they have not been specified by .tfvars files. 